### PR TITLE
Fix build error caused by mkdocs (v1.5.0)

### DIFF
--- a/mkdocs_charts_plugin/plugin.py
+++ b/mkdocs_charts_plugin/plugin.py
@@ -40,7 +40,7 @@ class ChartsPlugin(BasePlugin):
         """
         # Add pointer to mkdocs-charts-plugin.js
         # which is added to the output directory during on_post_build() event
-        config["extra_javascript"] = ["js/mkdocs-charts-plugin.js"] + config["extra_javascript"]
+        config["extra_javascript"] = ["js/mkdocs-charts-plugin.js"] + [str(item) for item in config["extra_javascript"]]
 
         # Make sure custom fences are configured.
         custom_fences = config.get("mdx_configs", {}).get("pymdownx.superfences", {}).get("custom_fences", {})


### PR DESCRIPTION
Fix https://github.com/timvink/mkdocs-charts-plugin/issues/16#issue-1823961327 as suggested by mkdocs' release note:

> Breaking change: `config.extra_javascript` is no longer a plain list of strings, but instead a list of `ExtraScriptValue` items. So you can no longer treat the list values as strings. If you want to keep compatibility with old versions, just always reference the items as `str(item)` instead. And you can still append plain strings to the list if you wish.